### PR TITLE
Include potypo.ini if it exists, fixes #14

### DIFF
--- a/potypo/__main__.py
+++ b/potypo/__main__.py
@@ -26,7 +26,7 @@ def load_classes(module, config):
 
 def main():
     config = configparser.ConfigParser()
-    config.read(['setup.cfg', 'tox.ini'])
+    config.read(['potypo.ini', 'setup.cfg', 'tox.ini'])
     conf = config['potypo']
 
     if 'locales_dir' not in conf:


### PR DESCRIPTION
`configparser` doesn't care if a file does not exist:

https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read